### PR TITLE
Fixed memory leak when using GPU acceleration.

### DIFF
--- a/src/_spimage_reconstructor.py
+++ b/src/_spimage_reconstructor.py
@@ -20,9 +20,9 @@ class Reconstructor:
         self._sp_phaser_dirty = True
         self._use_gpu = use_gpu
         # other stuff
-        self.clear()
+        self.__del__()
 
-    def clear(self):
+    def __del__(self):
         """
         Clears the instance reconstructor and deletes all configuration and data associated to it.
         """

--- a/src/_spimage_reconstructor.py
+++ b/src/_spimage_reconstructor.py
@@ -20,9 +20,9 @@ class Reconstructor:
         self._sp_phaser_dirty = True
         self._use_gpu = use_gpu
         # other stuff
-        self.__del__()
+        self.clear()
 
-    def __del__(self):
+    def clear(self):
         """
         Clears the instance reconstructor and deletes all configuration and data associated to it.
         """

--- a/src/_spimage_reconstructor.py
+++ b/src/_spimage_reconstructor.py
@@ -8,9 +8,7 @@ logger.setLevel("WARNING")
 
 class Reconstructor:
     def __init__(self, use_gpu=True):
-        # mask
         self._mask = None
-        # wrapped C-object instances
         self._sp_amplitudes = None
         self._sp_amplitudes_dirty = True
         self._sp_initial_support = None
@@ -19,7 +17,6 @@ class Reconstructor:
         self._sp_phaser = None
         self._sp_phaser_dirty = True
         self._use_gpu = use_gpu
-        # other stuff
         self.clear()
 
     def clear(self):
@@ -106,6 +103,9 @@ class Reconstructor:
             elif mode == "ERROR":
                 f = logger.error
             f(" %s %s" % (ps,s))
+
+    def __del__(self):
+        self.clear() 
 
     def set_intensities(self,intensities,shifted=False):
         """


### PR DESCRIPTION
When using the Python interface the memory on the GPU wasn't properly freed 
during subsequent iterations. This would eventually fill up all GPU memory. 
Fixed by properly adding a __del__ method that is implicitly called. 